### PR TITLE
set specific uid for mona-uds-agent runner user

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -64,4 +64,6 @@ spec:
 
 #### Deployment notes:
 * Specifying MONA_USER_ID and using the YAML without any changes will result in the best performance.
+  
+* Adding SOCKET_UID env var to the DaemonSet YAML allows setting a specific UID in order to use sockey between mona-uds-agent and mona-client which uses a specific UID (Default UID: 1000) 
 * Minimal requirement is 1 CPU, 2GB memory.

--- a/agent/README.md
+++ b/agent/README.md
@@ -65,5 +65,5 @@ spec:
 #### Deployment notes:
 * Specifying MONA_USER_ID and using the YAML without any changes will result in the best performance.
   
-* Adding SOCKET_UID env var to the DaemonSet YAML allows setting a specific UID in order to use sockey between mona-uds-agent and mona-client which uses a specific UID (Default UID: 1000) 
+* Adding SOCKET_UID env var to the DaemonSet YAML allows setting a specific UID in order to use a socket between mona-uds-agent and a container running mona-uds-client (which uses this UID). Default UID: 1000.
 * Minimal requirement is 1 CPU, 2GB memory.

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -4,7 +4,7 @@ LABEL Description="Mona Agent for Unix Domain Sockets"
 USER root
 RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
     && apt-get update \
-    && apt-get install -y --no-install-recommends sudo make gcc g++ libc-dev ruby-dev vim \
+    && apt-get install -y --no-install-recommends sudo make gcc g++ libc-dev ruby-dev vim gosu dumb-init \
     && sudo gem sources --clear-all \
     && sudo gem install fluent-plugin-multiprocess \
     && SUDO_FORCE_REMOVE=yes \
@@ -18,12 +18,16 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
 
 COPY fluent*.conf /fluentd/etc/
 RUN mkdir -p /var/run/mona && \
-    chown -R 999:999 /var/run/mona/
+    mkdir -p /home/fluent && \
+    chmod -R a=rw /var/run/mona/
+
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
 
 # Default Environment Variable
 ENV UDS_SERVER_ADDRESS="/var/run/mona/mona.sock"
 ENV LOG_LEVEL="warn"
-
+ENV FLUENTD_OPT=""
 ENV FLUSH_INTERVAL="30s"
 ENV MONA_REST_TIMEOUT=5
 ENV MONA_REST_FORMAT_TYPE="json"
@@ -35,5 +39,4 @@ ENV BUFFER_TYPE="file"
 ENV CHUNK_MAX_SIZE="16MB"
 ENV CHUNK_MAX_RECORD_COUNT=1000
 
-USER fluent
-
+ENTRYPOINT ["/entrypoint.sh"]

--- a/agent/docker/entrypoint.sh
+++ b/agent/docker/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/dumb-init /bin/sh
+
+uid=${SOCKET_UID:-1000}
+
+
+deluser fluent > /dev/null 2>&1
+# (re)add the fluent user with $SOCKET_UID
+adduser --disabled-password --uid ${uid} --home /home/fluent fluent > /dev/null 2>&1
+
+# chown data folders
+chown -R fluent /home/fluent > /dev/null 2>&1
+chown -R fluent /fluentd > /dev/null 2>&1
+chown -R fluent /tmp/buffer > /dev/null 2>&1
+
+gosu fluent fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT "$@"


### PR DESCRIPTION
On platforms where you already have a specific unix uid in use, we enabled the option to set a specific uid to the fluentd runner user on mona-uds-agent.