### PR TITLE
Don't allow blocking operation of sending mona data to exceed given timeout

### DIFF
--- a/mona_uds_client/mona_uds_client_test.py
+++ b/mona_uds_client/mona_uds_client_test.py
@@ -9,17 +9,21 @@ from random import random
 
 from mona_uds_client import MonaUdsClient, MonaSingleMessage
 
+NUM_BATCHES = 40
+
 
 def actual_run():
     logging.getLogger().setLevel(logging.INFO)
     client = MonaUdsClient("test_mona_user_id")
     logging.getLogger().setLevel(environ.get("LOGLEVEL", logging.INFO))
+    logging.info("starting client test")
     start_time = time.time()
     test_batches = [
         [{f"field_{i}": random() for i in range(150)} for _ in range(50)]  # nosec
-        for _ in range(10)
+        for _ in range(NUM_BATCHES)
     ]
-    for batch in test_batches:
+    successes = 0
+    for ind, batch in enumerate(test_batches):
         messages = [
             MonaSingleMessage(
                 contextId=str(uuid1()),
@@ -29,9 +33,12 @@ def actual_run():
             )
             for msg in batch
         ]
-        client.export(messages)
+        if client.export(messages):
+            successes += 1
+        else:
+            logging.warning(f"failed on index {ind}")
 
-    logging.info("all messages sent!")
+    logging.info(f"sent messges: {successes}/{NUM_BATCHES}")
     logging.info(f"took {time.time() - start_time} sec")
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mona_uds_client",
-    version="0.0.6",
+    version="0.0.7",
     author="MonaLabs",
     author_email="nemo@monalabs.io",
     description="Client code for python Mona over Unix Domain Socket protocol",


### PR DESCRIPTION
With default: 0.5 seconds we now limit the time it takes to push data into the mona agent, as failsafe
Also: fixed bug in the init of the raise_exceptions flag - was tuple accidentally
Also: improved the test a bit (mostly logging)

Tested locally.

@tzachmona FYI